### PR TITLE
Fix Haxe 3.4 compatibility

### DIFF
--- a/src/json2object/utils/schema/DataBuilder.hx
+++ b/src/json2object/utils/schema/DataBuilder.hx
@@ -40,7 +40,7 @@ using StringTools;
 class DataBuilder {
 
 	static var counter:Int = 0;
-	static final definitions = new Map<String, JsonType>();
+	static var definitions = new Map<String, JsonType>();
 
 	private inline static function describe (type:JsonType, descr:Null<String>) {
 		return (descr == null) ? type : JTWithDescr(type, descr);


### PR DESCRIPTION
At least according to the Travis config, 3.4 is meant to be supported, but I guess the schema classes aren't included in CI builds. :)