### PR TITLE
Cleanup unnecessary Haxe version check

### DIFF
--- a/src/json2object/utils/schema/DataBuilder.hx
+++ b/src/json2object/utils/schema/DataBuilder.hx
@@ -75,7 +75,7 @@ class DataBuilder {
 						var ft = ft.followWithAbstracts();
 						jt = anyOf(jt, makeSchema(ft, definitions));
 					}
-					catch (_:#if (haxe_ver >= 4) Any #else Dynamic #end) {}
+					catch (_:Dynamic) {}
 				}
 				if (jt == null) {
 					throw "Abstract "+name+ " has no json representation "+ Context.currentPos();
@@ -126,7 +126,7 @@ class DataBuilder {
 					try {
 						jt = anyOf(jt, describe(handleExpr(field.expr().expr), field.doc));
 					}
-					catch (_:#if (haxe_ver >= 4) Any #else Dynamic #end) {}
+					catch (_:Dynamic) {}
 				}
 			default:
 		}
@@ -265,7 +265,7 @@ class DataBuilder {
 			define(name, JTObject(properties, required), definitions, doc);
 			return JTRef(name);
 		}
-		catch (e:#if (haxe_ver >= 4) Any #else Dynamic #end) {
+		catch (e:Dynamic) {
 			if (definitions.get(name) == null) {
 				definitions.remove(name);
 			}


### PR DESCRIPTION
Stumbled over this while looking at the code. As far as I can tell, the two behave exactly the same here, so there isn't really a point to conditionalizing? `Any` is nicer in theory of course, but not anymore once you have to conditionalize it. :)