### PR TITLE
Adding cache safety to data builder

### DIFF
--- a/src/json2object/reader/DataBuilder.hx
+++ b/src/json2object/reader/DataBuilder.hx
@@ -40,6 +40,7 @@ typedef ParserInfo = {packs:Array<String>, clsName:String}
 
 class DataBuilder {
 
+	@:persistent
 	private static var counter = 0;
 	private static var parsers = new Map<String, Type>();
 	private static var callPosition:Null<haxe.macro.Position> = null;

--- a/src/json2object/writer/DataBuilder.hx
+++ b/src/json2object/writer/DataBuilder.hx
@@ -35,7 +35,7 @@ using haxe.macro.ExprTools;
 using json2object.utils.TypeTools;
 
 class DataBuilder {
-
+	@:persistent
 	private static var counter = 0;
 	private static var writers = new Map<String, Type>();
 	private static var jcustom = ":jcustomwrite";


### PR DESCRIPTION
The issue is described here:

https://github.com/elnabo/json2object/issues/74

I have not tested this extensively. Just wanted to get the ball rolling.