### PR TITLE
Nightly Safe Macros

### DIFF
--- a/src/json2object/TypeUtils.hx
+++ b/src/json2object/TypeUtils.hx
@@ -118,5 +118,9 @@ class TypeUtils
 
 		return t;
 	}
+
+	public static function isAlive(ct:ComplexType, pos:Position):Type {
+		return try Context.resolveType(ct, pos) catch(e) null;
+	}
 }
 #end

--- a/src/json2object/reader/DataBuilder.hx
+++ b/src/json2object/reader/DataBuilder.hx
@@ -44,10 +44,6 @@ class DataBuilder {
 	private static var callPosition:Null<Position> = null;
 	private static var jcustom = ":jcustomparse";
 
-	static function isAlive(ct:ComplexType, pos:Position):Type {
-		return try Context.resolveType(ct, pos) catch(e) null;
-	}
-
 	private static function notNull(type:Type):Type {
 		return switch (type) {
 			case TAbstract(_.get()=>t, p):
@@ -942,7 +938,7 @@ class DataBuilder {
 		var parser_cls = { name: parserName, pack: [], params: null, sub: null };
 
 		if (parsers.exists(parserName)) {
-			var resolved = isAlive(TPath(parser_cls), Context.currentPos());
+			var resolved = TypeUtils.isAlive(TPath(parser_cls), Context.currentPos());
 			if (resolved != null) {
 				return resolved;
 			}

--- a/src/json2object/utils/schema/DataBuilder.hx
+++ b/src/json2object/utils/schema/DataBuilder.hx
@@ -42,9 +42,43 @@ typedef Definitions = Map<String, JsonType>;
 
 class DataBuilder {
 
-	static var BOOL = Context.getType("Bool");
-	static var FLOAT = Context.getType("Float");
-	static var STRING = Context.getType("String");
+	@:persistent
+	static var cachedBool:Type = null;
+	@:persistent
+	static var cachedFloat:Type = null;
+	@:persistent
+	static var cachedString:Type = null;
+
+	static var BOOL(get, never):Type;
+	static var FLOAT(get, never):Type;
+	static var STRING(get, never):Type;
+
+	static function get_BOOL() {
+		return switch cachedBool {
+			case null:
+				cachedBool = Context.getType("Bool");
+			case cached:
+				cached;
+		}
+	}
+
+	static function get_FLOAT() {
+		return switch cachedFloat {
+			case null:
+				cachedFloat = Context.getType("Float");
+			case cached:
+				cached;
+		}
+	}
+
+	static function get_STRING() {
+		return switch cachedString {
+			case null:
+				cachedString = Context.getType("String");
+			case cached:
+				cached;
+		}
+	}
 
 	@:persistent
 	private static var writers = new Map<String, Bool>();

--- a/src/json2object/utils/schema/DataBuilder.hx
+++ b/src/json2object/utils/schema/DataBuilder.hx
@@ -413,8 +413,6 @@ class DataBuilder {
 	}
 
 	static function makeSchemaWriter(c:BaseType, type:Type, parsingType:ParsingType) {
-		trace(Std.string(parsingType));
-
 		var swriterName = c.name + "_" + haxe.crypto.Md5.encode(type.toString() + Std.string(parsingType));
 		var swriter_cls = { name: swriterName, pack: [], params: null, sub: null };
 

--- a/src/json2object/utils/schema/DataBuilder.hx
+++ b/src/json2object/utils/schema/DataBuilder.hx
@@ -42,11 +42,8 @@ typedef Definitions = Map<String, JsonType>;
 
 class DataBuilder {
 
-	@:persistent
 	static var cachedBool:Type = null;
-	@:persistent
 	static var cachedFloat:Type = null;
-	@:persistent
 	static var cachedString:Type = null;
 
 	static var BOOL(get, never):Type;


### PR DESCRIPTION
This attempts to update the reader and writer macros to play nicely with haxe nightlies completion.

The type of the reader / writer is hashed and used as part of the generated types name and it will avoid defining multiple classes for the same type, this is following the guidelines from this PR (https://github.com/HaxeFoundation/haxe/pull/11159).

This seems to work nicely in my experience so far, previously completion use to fall apart around parsers but it seems to be holding up well so far.

The `defineType` call in `copyType` still seems a bit dodgy, but I'm not sure why this function exists / when its exactly used yet.

cc @kLabz in case they want to make sure I've not misunderstood that haxe PRs purpose.